### PR TITLE
Fix tsconfig module option lines

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
     "incremental": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- split `resolveJsonModule` and `isolatedModules` in `tsconfig.json`

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('tsconfig.json','utf8')); console.log('valid');"`


------
https://chatgpt.com/codex/tasks/task_b_6854430d26ac832ebb0ac4abfaa2daa8