### PR TITLE
Fix PDF generation and add landing components

### DIFF
--- a/apps/web/app/actions/pdf-generator.ts
+++ b/apps/web/app/actions/pdf-generator.ts
@@ -145,7 +145,8 @@ This CV was generated using a basic PDF fallback because the primary
 PDF generation failed. For full fidelity, please try again later.
 `;
 
-    const { default: PDFDocument } = await import('pdfkit');
+    // Use standalone build to ensure standard fonts are bundled
+    const { default: PDFDocument } = await import('pdfkit/js/pdfkit.standalone.js');
     const doc = new PDFDocument();
     const buffers: Buffer[] = [];
     doc.on('data', (chunk: Buffer) => buffers.push(chunk));

--- a/apps/web/app/components/footer.tsx
+++ b/apps/web/app/components/footer.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function Footer() {
+  return (
+    <footer className="border-t p-4 text-center text-sm text-muted-foreground">
+      <p>&copy; {new Date().getFullYear()} AutoCV. All rights reserved.</p>
+      <div className="mt-2 flex justify-center gap-4">
+        <Link href="/templates" className="hover:underline">
+          Templates
+        </Link>
+        <Link href="/builder" className="hover:underline">
+          Get Started
+        </Link>
+      </div>
+    </footer>
+  );
+}
+

--- a/apps/web/app/components/header.tsx
+++ b/apps/web/app/components/header.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import { Button } from '@cv-generator/ui';
+
+export default function Header() {
+  return (
+    <header className="flex items-center justify-between p-4 border-b">
+      <h1 className="text-xl font-bold">AutoCV</h1>
+      <nav className="flex items-center gap-4">
+        <Link href="/templates" className="text-sm">
+          Templates
+        </Link>
+        <Button asChild size="sm">
+          <Link href="/builder">Get Started</Link>
+        </Button>
+      </nav>
+    </header>
+  );
+}
+

--- a/apps/web/app/components/hero.tsx
+++ b/apps/web/app/components/hero.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import { Button } from '@cv-generator/ui';
+
+export default function Hero() {
+  return (
+    <section className="flex flex-col items-center justify-center text-center px-4 py-20">
+      <h2 className="text-3xl sm:text-5xl font-bold max-w-2xl mx-auto">
+        Create Professional CVs in <span className="text-purple-500">Minutes</span>
+      </h2>
+      <p className="mt-4 text-sm sm:text-lg text-muted-foreground max-w-2xl">
+        Build, customize, and export professional CVs with AI-powered content improvement and job-specific tailoring. Stand out from the crowd with ATS-friendly templates.
+      </p>
+      <div className="mt-8 flex flex-col sm:flex-row gap-4">
+        <Button asChild size="lg">
+          <Link href="/builder">Start Creating CV</Link>
+        </Button>
+        <Button asChild variant="outline" size="lg">
+          <Link href="/templates">View Templates</Link>
+        </Button>
+      </div>
+    </section>
+  );
+}
+

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,34 +1,15 @@
-import Link from 'next/link';
-import { Button } from '@cv-generator/ui';
+import Header from './components/header';
+import Hero from './components/hero';
+import Footer from './components/footer';
 
 export default function LandingPage() {
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="flex items-center justify-between p-4 border-b">
-        <h1 className="text-xl font-bold">AutoCV</h1>
-        <nav className="flex items-center gap-4">
-          <Link href="/templates" className="text-sm">Templates</Link>
-          <Button asChild size="sm">
-            <Link href="/builder">Get Started</Link>
-          </Button>
-        </nav>
-      </header>
-      <main className="flex-1 flex flex-col items-center justify-center text-center px-4 py-20">
-        <h2 className="text-3xl sm:text-5xl font-bold max-w-2xl mx-auto">
-          Create Professional CVs in <span className="text-purple-500">Minutes</span>
-        </h2>
-        <p className="mt-4 text-sm sm:text-lg text-muted-foreground max-w-2xl">
-          Build, customize, and export professional CVs with AI-powered content improvement and job-specific tailoring. Stand out from the crowd with ATS-friendly templates.
-        </p>
-        <div className="mt-8 flex flex-col sm:flex-row gap-4">
-          <Button asChild size="lg">
-            <Link href="/builder">Start Creating CV</Link>
-          </Button>
-          <Button asChild variant="outline" size="lg">
-            <Link href="/templates">View Templates</Link>
-          </Button>
-        </div>
+      <Header />
+      <main className="flex-1">
+        <Hero />
       </main>
+      <Footer />
     </div>
   );
 }

--- a/apps/web/declarations.d.ts
+++ b/apps/web/declarations.d.ts
@@ -35,3 +35,4 @@ declare module '@cv-generator/utils/shared' {
 }
 
 declare module 'pdfkit';
+declare module 'pdfkit/js/pdfkit.standalone.js';


### PR DESCRIPTION
## Summary
- bundle default fonts for PDFKit fallback using standalone build
- restructure landing page with header, hero, and footer components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c1659a81a08326a4d2dc420eb7d577