### PR TITLE
Rename AutoCV references to GenCV

### DIFF
--- a/apps/web/app/components/footer.tsx
+++ b/apps/web/app/components/footer.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 export default function Footer() {
   return (
     <footer className="border-t p-4 text-center text-sm text-muted-foreground">
-      <p>&copy; {new Date().getFullYear()} AutoCV. All rights reserved.</p>
+      <p>&copy; {new Date().getFullYear()} GenCV. All rights reserved.</p>
       <div className="mt-2 flex justify-center gap-4">
         <Link href="/templates" className="hover:underline">
           Templates

--- a/apps/web/app/components/header.tsx
+++ b/apps/web/app/components/header.tsx
@@ -4,7 +4,7 @@ import { Button } from '@cv-generator/ui';
 export default function Header() {
   return (
     <header className="flex items-center justify-between p-4 border-b">
-      <h1 className="text-xl font-bold">AutoCV</h1>
+      <h1 className="text-xl font-bold">GenCV</h1>
       <nav className="flex items-center gap-4">
         <Link href="/templates" className="text-sm">
           Templates


### PR DESCRIPTION
## Summary
- rename header branding to GenCV
- update footer branding to GenCV
- remove remaining AutoCV references

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c16cedf4b88326bb30b0f05ed33d60