### PR TITLE
feat(web): enhance landing page with new sections

### DIFF
--- a/apps/web/app/components/cta.tsx
+++ b/apps/web/app/components/cta.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+import { Button } from '@cv-generator/ui';
+
+export default function CTA() {
+  return (
+    <section className="py-20 bg-gradient-to-r from-purple-500 to-indigo-500 text-white">
+      <div className="max-w-4xl mx-auto px-4 text-center">
+        <h2 className="text-3xl sm:text-4xl font-bold">Ready to build your CV?</h2>
+        <p className="mt-4 text-lg">
+          Start creating a professional, job-winning CV in minutes.
+        </p>
+        <Button
+          asChild
+          size="lg"
+          className="mt-8 bg-white text-purple-600 hover:bg-gray-100"
+        >
+          <Link href="/builder">Get Started</Link>
+        </Button>
+      </div>
+    </section>
+  );
+}
+

--- a/apps/web/app/components/features.tsx
+++ b/apps/web/app/components/features.tsx
@@ -1,0 +1,51 @@
+import { Card, CardHeader, CardTitle, CardDescription } from '@cv-generator/ui';
+import { Sparkles, LayoutTemplate, FileCheck2, Download } from 'lucide-react';
+
+const features = [
+  {
+    icon: Sparkles,
+    title: 'AI-Assisted Writing',
+    description:
+      'Generate and improve your CV content with smart suggestions powered by AI.',
+  },
+  {
+    icon: LayoutTemplate,
+    title: 'Customizable Templates',
+    description:
+      'Choose from professionally designed templates and tailor them to your style.',
+  },
+  {
+    icon: FileCheck2,
+    title: 'ATS Friendly',
+    description:
+      'Ensure your CV passes applicant tracking systems with optimized formatting.',
+  },
+  {
+    icon: Download,
+    title: 'Easy Export',
+    description:
+      'Download your CV in multiple formats ready for job applications.',
+  },
+];
+
+export default function Features() {
+  return (
+    <section className="py-20 bg-muted/50">
+      <div className="max-w-6xl mx-auto px-4">
+        <h2 className="text-3xl sm:text-4xl font-bold text-center">Features</h2>
+        <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {features.map((feature, index) => (
+            <Card key={index} className="text-center">
+              <CardHeader>
+                <feature.icon className="w-10 h-10 mx-auto text-purple-500" />
+                <CardTitle className="mt-4 text-xl">{feature.title}</CardTitle>
+                <CardDescription>{feature.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/apps/web/app/components/process.tsx
+++ b/apps/web/app/components/process.tsx
@@ -1,0 +1,41 @@
+import { FileText, Edit3, Send } from 'lucide-react';
+
+const steps = [
+  {
+    icon: FileText,
+    title: 'Choose Template',
+    description: 'Select a professional design that suits your industry and style.',
+  },
+  {
+    icon: Edit3,
+    title: 'Customize Content',
+    description: 'Fill in your details and let AI polish your language and format.',
+  },
+  {
+    icon: Send,
+    title: 'Download & Apply',
+    description: 'Export your CV and start applying to your dream jobs right away.',
+  },
+];
+
+export default function Process() {
+  return (
+    <section className="py-20">
+      <div className="max-w-6xl mx-auto px-4">
+        <h2 className="text-3xl sm:text-4xl font-bold text-center">How It Works</h2>
+        <div className="mt-10 grid gap-8 sm:grid-cols-3">
+          {steps.map((step, index) => (
+            <div key={index} className="text-center">
+              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-purple-500 text-white">
+                <step.icon className="h-6 w-6" />
+              </div>
+              <h3 className="mt-4 text-xl font-semibold">{step.title}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">{step.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,5 +1,8 @@
 import Header from './components/header';
 import Hero from './components/hero';
+import Features from './components/features';
+import Process from './components/process';
+import CTA from './components/cta';
 import Footer from './components/footer';
 
 export default function LandingPage() {
@@ -8,6 +11,9 @@ export default function LandingPage() {
       <Header />
       <main className="flex-1">
         <Hero />
+        <Features />
+        <Process />
+        <CTA />
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- add features section with four cards and icons
- add 3-step process flow
- add closing call-to-action and render sections on landing page

## Testing
- `npm --workspace apps/web run lint`
- `npm --workspace apps/web run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c16ebd640483269026ad2fb46216cb