### PR TITLE
Allow small PDFs and harden generate-pdf API

### DIFF
--- a/apps/web/app/api/generate-pdf/route.ts
+++ b/apps/web/app/api/generate-pdf/route.ts
@@ -10,20 +10,36 @@ export const dynamic = 'force-dynamic'; // Memastikan bahwa route ini tidak di-c
 // Main handler for PDF generation
 export async function POST(request: NextRequest) {
   console.log('PDF generation request received:', request.url);
-  
+
   try {
-    // Parse the request body
-    const { cvData, template } = await request.json();
+    // Parse the request body with explicit error handling
+    let body: any;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON body' },
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { cvData, template } = body as { cvData?: CVData; template?: string };
+    if (!cvData) {
+      return NextResponse.json(
+        { error: 'Missing cvData' },
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
     console.log('Processing PDF request with template:', template);
-    
-    // Generate PDF or text fallback using server action
-    const { buffer, isText, filename } = await generatePDF(cvData, template || 'modern');
-    console.log(`Generated ${isText ? 'text fallback' : 'PDF'}, size:`, buffer.length);
-    
+
+    // Generate PDF using server action
+    const { buffer, filename } = await generatePDF(cvData, template || 'modern');
+    console.log('Generated PDF, size:', buffer.length);
+
     // Get PDF signature for debugging
     const signature = buffer.slice(0, 5).toString('utf-8');
     console.log('File signature:', signature);
-    
+
     // Convert the buffer to a ReadableStream
     const stream = new ReadableStream({
       start(controller) {
@@ -31,44 +47,39 @@ export async function POST(request: NextRequest) {
         controller.close();
       }
     });
-    
-    // Set appropriate content type
-    const contentType = isText ? 'text/plain' : 'application/pdf';
-    
+
     return new NextResponse(stream, {
       status: 200,
       headers: {
-        'Content-Type': contentType,
+        'Content-Type': 'application/pdf',
         'Content-Disposition': `attachment; filename="${filename}"`,
         'Content-Length': buffer.length.toString(),
         'Cache-Control': 'no-cache, no-store, must-revalidate',
         'Pragma': 'no-cache',
         'Expires': '0',
         // Debug headers
-        'X-PDF-Method': isText ? 'fallback-text' : 'puppeteer-pdf',
         'X-PDF-Size': buffer.length.toString(),
         'X-PDF-Signature': signature
       },
     });
   } catch (error) {
     console.error('PDF Generation Error:', error);
-    
-    // Get more detailed error information
+
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     const errorStack = error instanceof Error ? error.stack : '';
-    
+
     console.error('Error details:', {
       message: errorMessage,
       stack: errorStack
     });
-    
+
     return NextResponse.json(
-      { 
-        error: 'PDF generation failed', 
+      {
+        error: 'PDF generation failed',
         details: errorMessage,
-        stack: process.env.NODE_ENV === 'development' ? errorStack : undefined 
+        stack: process.env.NODE_ENV === 'development' ? errorStack : undefined
       },
-      { status: 500 }
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
     );
   }
 }

--- a/apps/web/app/components/cv-preview/index-clean.tsx
+++ b/apps/web/app/components/cv-preview/index-clean.tsx
@@ -77,7 +77,7 @@ export function CVPreview({ cvData, template = 'modern' }: CVPreviewProps) {
         throw new Error(`Invalid PDF format (signature: ${signatureText}, type: ${blob.type})`);
       }
       
-      if (blob.size < 5000) {
+      if (blob.size < 1000) {
         throw new Error(`PDF file too small (${blob.size} bytes), likely corrupted`);
       }
       

--- a/apps/web/app/components/cv-preview/index.tsx
+++ b/apps/web/app/components/cv-preview/index.tsx
@@ -76,8 +76,8 @@ export function CVPreview({ cvData, template = 'modern' }: CVPreviewProps) {
         throw new Error(`Invalid PDF format (signature: ${signatureText}, type: ${blob.type})`);
       }
       
-      // Validate blob size
-      if (blob.size < 5000) {
+      // Validate blob size - ensure at least 1KB to avoid empty files
+      if (blob.size < 1000) {
         throw new Error(`PDF file too small (${blob.size} bytes), likely corrupted`);
       }
         // Create download link

--- a/apps/web/app/result/page.tsx
+++ b/apps/web/app/result/page.tsx
@@ -75,8 +75,8 @@ export default function ResultPage() {
         throw new Error(`Invalid PDF format (signature: ${signatureText}, type: ${blob.type})`);
       }
       
-      // Validate blob size - should be substantial for a PDF
-      if (blob.size < 5000) {
+      // Validate blob size - should be at least 1KB to avoid empty responses
+      if (blob.size < 1000) {
         throw new Error(`PDF file too small (${blob.size} bytes), likely corrupted or error response`);
       }
       


### PR DESCRIPTION
## Summary
- Allow downloading PDFs as small as 1KB instead of enforcing a 5KB minimum
- Return consistent `application/pdf` from `/api/generate-pdf` and add explicit JSON error responses

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `node -e "console.log('sample test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c174b336408326853cbcad9eec925e