### PR TITLE
feat: connect frontend to deployed backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Vercel deployment env vars
 # Tambahkan variable ini di Vercel dashboard
 GEMINI_API_KEY=
-NEXT_PUBLIC_API_URL=/api
+# Base URL of the PDF generation backend
+NEXT_PUBLIC_API_URL=https://gencvbackend-web.vercel.app
 TURBO_TELEMETRY_DISABLED=1
 
 # Local Development - Sesuaikan dengan path instalasi Chrome Anda

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,5 @@
 # API Configuration
-NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_API_URL=https://gencvbackend-web.vercel.app
 
 # Application Configuration
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/apps/web/app/components/cv-preview/index.tsx
+++ b/apps/web/app/components/cv-preview/index.tsx
@@ -20,8 +20,9 @@ export function CVPreview({ cvData, template = 'modern' }: CVPreviewProps) {
   const handleDownload = async () => {
     try {
       console.log('Starting PDF download from CV Preview...');
+      const apiUrl = (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/$/, '');
       // Fetch PDF using proper blob handling
-      const response = await fetch(`/api/generate-pdf`, {
+      const response = await fetch(`${apiUrl}/api/generate-pdf`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/web/app/result/page.tsx
+++ b/apps/web/app/result/page.tsx
@@ -23,11 +23,12 @@ export default function ResultPage() {
     if (!cvData) return;
     
     try {
-      // Gunakan API endpoint yang baru di Next.js API routes
+      // Gunakan API endpoint dari backend terpisah
       console.log('Starting PDF download...');
-      
+      const apiUrl = (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/$/, '');
+
       // Use fetch with explicit blob response type to preserve binary data
-      const response = await fetch(`/api/generate-pdf`, {
+      const response = await fetch(`${apiUrl}/api/generate-pdf`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- fetch PDF from external backend using `NEXT_PUBLIC_API_URL`
- document backend URL in environment examples

## Testing
- `npm run lint` *(fails: turbo not found; installing turbo denied with 403)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c3efd5a95c83269a95dc5d7e3413f5