### PR TITLE
feat(web): default API URL for downloads

### DIFF
--- a/apps/web/app/components/cv-preview/index-clean.tsx
+++ b/apps/web/app/components/cv-preview/index-clean.tsx
@@ -20,10 +20,10 @@ export function CVPreview({ cvData, template = 'modern' }: CVPreviewProps) {
   
   const handleDownload = async () => {
     try {
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
-      
+      const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://gencvbackend-web.vercel.app').replace(/\/$/, '');
+
       console.log('Starting PDF download from CV Preview...');
-      
+
       const response = await fetch(`${apiUrl}/api/generate-pdf`, {
         method: 'POST',
         headers: {
@@ -31,10 +31,9 @@ export function CVPreview({ cvData, template = 'modern' }: CVPreviewProps) {
           'Accept': 'application/pdf',
           'Cache-Control': 'no-cache',
         },
-        credentials: 'include',
-        body: JSON.stringify({ 
-          cvData, 
-          template: template === 'preview' ? 'modern' : template 
+        body: JSON.stringify({
+          cvData,
+          template: template === 'preview' ? 'modern' : template
         }),
       });
       

--- a/apps/web/app/components/cv-preview/index.tsx
+++ b/apps/web/app/components/cv-preview/index.tsx
@@ -20,7 +20,7 @@ export function CVPreview({ cvData, template = 'modern' }: CVPreviewProps) {
   const handleDownload = async () => {
     try {
       console.log('Starting PDF download from CV Preview...');
-      const apiUrl = (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/$/, '');
+      const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://gencvbackend-web.vercel.app').replace(/\/$/, '');
       // Fetch PDF using proper blob handling
       const response = await fetch(`${apiUrl}/api/generate-pdf`, {
         method: 'POST',
@@ -29,10 +29,9 @@ export function CVPreview({ cvData, template = 'modern' }: CVPreviewProps) {
           'Accept': 'application/pdf', // Explicitly request PDF format
           'Cache-Control': 'no-cache', // Prevent caching
         },
-        credentials: 'include', // Include credentials if using sessions/cookies
-        body: JSON.stringify({ 
-          cvData, 
-          template: template === 'preview' ? 'modern' : template 
+        body: JSON.stringify({
+          cvData,
+          template: template === 'preview' ? 'modern' : template
         }),
       });
       

--- a/apps/web/app/result/page.tsx
+++ b/apps/web/app/result/page.tsx
@@ -25,7 +25,7 @@ export default function ResultPage() {
     try {
       // Gunakan API endpoint dari backend terpisah
       console.log('Starting PDF download...');
-      const apiUrl = (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/$/, '');
+      const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://gencvbackend-web.vercel.app').replace(/\/$/, '');
 
       // Use fetch with explicit blob response type to preserve binary data
       const response = await fetch(`${apiUrl}/api/generate-pdf`, {


### PR DESCRIPTION
## Summary
- default to https://gencvbackend-web.vercel.app when NEXT_PUBLIC_API_URL is unset
- drop fetch credentials for PDF generation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: turbo: not found)*
- `curl -v -X POST https://gencvbackend-web.vercel.app/api/generate-pdf -H 'Content-Type: application/json' -d '{}'` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b7ca259c832688d9bd806e2d74f4