### PR TITLE
refactor: unify API URL usage and error handling

### DIFF
--- a/apps/web/app/api/generate-docx/route.ts
+++ b/apps/web/app/api/generate-docx/route.ts
@@ -30,6 +30,7 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error('DOCX Generation Error:', error);
     return NextResponse.json(
       { error: 'DOCX generation failed', details: message },
       { status: 500 }

--- a/apps/web/app/components/cv-preview/index-clean.tsx
+++ b/apps/web/app/components/cv-preview/index-clean.tsx
@@ -8,6 +8,7 @@ import { calculateCVScore } from '@cv-generator/utils';
 import { ModernTemplate } from './templates/modern-template';
 import { ClassicTemplate } from './templates/classic-template';
 import { CreativeTemplate } from './templates/creative-template';
+import { getApiUrl } from '@/lib/api-url';
 
 interface CVPreviewProps {
   cvData: CVData;
@@ -20,7 +21,7 @@ export function CVPreview({ cvData, template = 'modern' }: CVPreviewProps) {
   
   const handleDownload = async () => {
     try {
-      const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://gencvbackend-web.vercel.app').replace(/\/$/, '');
+      const apiUrl = getApiUrl();
 
       console.log('Starting PDF download from CV Preview...');
 

--- a/apps/web/app/components/cv-preview/index.tsx
+++ b/apps/web/app/components/cv-preview/index.tsx
@@ -8,6 +8,7 @@ import { calculateCVScore, formatDate } from '@cv-generator/utils';
 import { ModernTemplate } from './templates/modern-template';
 import { ClassicTemplate } from './templates/classic-template';
 import { CreativeTemplate } from './templates/creative-template';
+import { getApiUrl } from '@/lib/api-url';
 
 interface CVPreviewProps {
   cvData: CVData;
@@ -20,7 +21,7 @@ export function CVPreview({ cvData, template = 'modern' }: CVPreviewProps) {
   const handleDownload = async () => {
     try {
       console.log('Starting PDF download from CV Preview...');
-      const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://gencvbackend-web.vercel.app').replace(/\/$/, '');
+      const apiUrl = getApiUrl();
       // Fetch PDF using proper blob handling
       const response = await fetch(`${apiUrl}/api/generate-pdf`, {
         method: 'POST',

--- a/apps/web/app/components/cv-wizard/steps/experience-step.tsx
+++ b/apps/web/app/components/cv-wizard/steps/experience-step.tsx
@@ -6,6 +6,7 @@ import { CVData, Experience } from '@cv-generator/types';
 import { Button, Input, Textarea, Card, CardContent, CardHeader, CardTitle } from '@cv-generator/ui';
 import { generateId } from '@cv-generator/utils';
 import { StepProps } from '../types';
+import { getApiUrl } from '@/lib/api-url';
 
 export function ExperienceStep({ cvData, onDataChange, onNext, onPrevious, isFirst }: StepProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -53,7 +54,8 @@ export function ExperienceStep({ cvData, onDataChange, onNext, onPrevious, isFir
     if (!experience || !experience.description.trim()) return;
 
     try {
-      const response = await fetch(`/api/ai`, {
+      const apiUrl = getApiUrl();
+      const response = await fetch(`${apiUrl}/api/ai`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -72,6 +74,7 @@ export function ExperienceStep({ cvData, onDataChange, onNext, onPrevious, isFir
       }
     } catch (error) {
       console.error('Failed to enhance description:', error);
+      alert(`Failed to enhance description: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   };
 

--- a/apps/web/app/components/cv-wizard/steps/professional-summary-step.tsx
+++ b/apps/web/app/components/cv-wizard/steps/professional-summary-step.tsx
@@ -5,6 +5,7 @@ import { Sparkles, RefreshCw } from 'lucide-react';
 import { CVData } from '@cv-generator/types';
 import { Button, Textarea, Card, CardContent, Badge } from '@cv-generator/ui';
 import { StepProps } from '../types';
+import { getApiUrl } from '@/lib/api-url';
 
 export function ProfessionalSummaryStep({ cvData, onDataChange, onNext, onPrevious, isFirst }: StepProps) {
   const [isGenerating, setIsGenerating] = useState(false);
@@ -45,7 +46,8 @@ export function ProfessionalSummaryStep({ cvData, onDataChange, onNext, onPrevio
         skillsCount: skillsList.length
       });
       
-      const response = await fetch(`/api/ai`, {
+      const apiUrl = getApiUrl();
+      const response = await fetch(`${apiUrl}/api/ai`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -69,7 +71,8 @@ export function ProfessionalSummaryStep({ cvData, onDataChange, onNext, onPrevio
         setError('Failed to generate summary. Please try again.');
       }
     } catch (error) {
-      setError('Network error. Please check your connection and try again.');
+      console.error('Failed to generate summary:', error);
+      setError(`Failed to generate summary: ${error instanceof Error ? error.message : 'Unknown error'}`);
     } finally {
       setIsGenerating(false);
     }

--- a/apps/web/app/components/cv-wizard/steps/projects-step.tsx
+++ b/apps/web/app/components/cv-wizard/steps/projects-step.tsx
@@ -7,6 +7,7 @@ import { Button, Input, Textarea, Card, CardContent, CardHeader, CardTitle, Badg
 import { generateId } from '@cv-generator/utils';
 import { StepProps } from '../types';
 import { useRouter } from 'next/navigation';
+import { getApiUrl } from '@/lib/api-url';
 
 export function ProjectsStep({ cvData, onDataChange, onNext, onPrevious, isFirst }: StepProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -84,7 +85,8 @@ export function ProjectsStep({ cvData, onDataChange, onNext, onPrevious, isFirst
     setErrors(prev => ({...prev, [projectId]: ''}));
 
     try {
-      const response = await fetch(`/api/ai`, {
+      const apiUrl = getApiUrl();
+      const response = await fetch(`${apiUrl}/api/ai`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -105,7 +107,11 @@ export function ProjectsStep({ cvData, onDataChange, onNext, onPrevious, isFirst
         setErrors(prev => ({...prev, [projectId]: result.error || 'Failed to generate description. Please try again.'}));
       }
     } catch (error) {
-      setErrors(prev => ({...prev, [projectId]: 'Network error. Please check your connection and try again.'}));
+      console.error('Failed to generate project description:', error);
+      setErrors(prev => ({
+        ...prev,
+        [projectId]: error instanceof Error ? error.message : 'Network error. Please check your connection and try again.'
+      }));
     } finally {
       setGeneratingDescriptions(prev => ({...prev, [projectId]: false}));
     }

--- a/apps/web/app/components/cv-wizard/steps/skills-step.tsx
+++ b/apps/web/app/components/cv-wizard/steps/skills-step.tsx
@@ -6,6 +6,7 @@ import { CVData, Skill } from '@cv-generator/types';
 import { Button, Input, Card, CardContent, Badge } from '@cv-generator/ui';
 import { generateId } from '@cv-generator/utils';
 import { StepProps } from '../types';
+import { getApiUrl } from '@/lib/api-url';
 
 const skillLevels = ['Beginner', 'Intermediate', 'Advanced', 'Expert'] as const;
 const skillCategories = ['Technical', 'Soft', 'Language'] as const;
@@ -45,7 +46,8 @@ export function SkillsStep({ cvData, onDataChange, onNext, onPrevious, isFirst }
     try {
       const targetRole = 'Software Developer'; // This could be extracted from experience or made configurable
       
-      const response = await fetch(`/api/ai`, {
+      const apiUrl = getApiUrl();
+      const response = await fetch(`${apiUrl}/api/ai`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -82,6 +84,7 @@ export function SkillsStep({ cvData, onDataChange, onNext, onPrevious, isFirst }
       }
     } catch (error) {
       console.error('Failed to generate skills:', error);
+      alert(`Failed to generate skills: ${error instanceof Error ? error.message : 'Unknown error'}`);
     } finally {
       setIsGenerating(false);
     }

--- a/apps/web/app/result/page.tsx
+++ b/apps/web/app/result/page.tsx
@@ -7,6 +7,7 @@ import { loadFromLocalStorage } from '@cv-generator/utils/browser';
 import { Download, ArrowLeft, Share2, FileJson, Upload, FileText } from 'lucide-react';
 import Link from 'next/link';
 import { CVPreview } from '../components/cv-preview';
+import { getApiUrl } from '@/lib/api-url';
 
 export default function ResultPage() {
   const [cvData, setCvData] = useState<CVData | null>(null);
@@ -25,7 +26,7 @@ export default function ResultPage() {
     try {
       // Gunakan API endpoint dari backend terpisah
       console.log('Starting PDF download...');
-      const apiUrl = (process.env.NEXT_PUBLIC_API_URL || 'https://gencvbackend-web.vercel.app').replace(/\/$/, '');
+      const apiUrl = getApiUrl();
 
       // Use fetch with explicit blob response type to preserve binary data
       const response = await fetch(`${apiUrl}/api/generate-pdf`, {
@@ -108,7 +109,8 @@ export default function ResultPage() {
     if (!cvData) return;
 
     try {
-      const response = await fetch(`/api/generate-docx`, {
+      const apiUrl = getApiUrl();
+      const response = await fetch(`${apiUrl}/api/generate-docx`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/apps/web/lib/api-url.ts
+++ b/apps/web/lib/api-url.ts
@@ -1,0 +1,3 @@
+export function getApiUrl(): string {
+  return (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/$/, '');
+}


### PR DESCRIPTION
## Summary
- add shared `getApiUrl` helper
- refactor client and wizard components to use shared API URL logic
- surface backend failures with console logging and user-facing errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: turbo: not found / 403 fetching turbo)*
- `npx tsc -p apps/web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c5bbc1210483268fd97b0225adc70a