### PR TITLE
fix: add puppeteer-core dependency and docx import compatibility

### DIFF
--- a/apps/web/app/actions/docx-generator.ts
+++ b/apps/web/app/actions/docx-generator.ts
@@ -1,7 +1,10 @@
 'use server';
 
 import { CVData } from '@cv-generator/types';
-import { Document, Packer, Paragraph, HeadingLevel } from 'docx';
+import * as docx from 'docx';
+import type { Paragraph as DocxParagraph } from 'docx';
+
+const { Document, Packer, Paragraph, HeadingLevel } = docx;
 
 export async function generateDOCX(cvData: CVData, _template: string): Promise<{
   buffer: Buffer;
@@ -10,7 +13,7 @@ export async function generateDOCX(cvData: CVData, _template: string): Promise<{
   const fullName = cvData.personalInfo?.fullName || 'cv';
   const safeFilename = fullName.replace(/[^a-zA-Z0-9.-]/g, '_');
 
-  const paragraphs: Paragraph[] = [];
+  const paragraphs: DocxParagraph[] = [];
 
   paragraphs.push(new Paragraph({ text: `CV - ${fullName}`, heading: HeadingLevel.TITLE }));
   paragraphs.push(new Paragraph({ text: '' }));

--- a/apps/web/declarations.d.ts
+++ b/apps/web/declarations.d.ts
@@ -36,3 +36,4 @@ declare module '@cv-generator/utils/shared' {
 
 declare module 'pdfkit';
 declare module 'pdfkit/js/pdfkit.standalone.js';
+declare module 'puppeteer';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,7 +33,8 @@
     "react-hook-form": "^7.53.0",
     "react-pdf": "^7.5.1",
     "tailwind-merge": "^2.5.2",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "puppeteer-core": "^22.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.6.2",


### PR DESCRIPTION
## Summary
- import docx via namespace and expose types for cleaner Next.js build
- add puppeteer-core dependency and stub puppeteer module for type checking

## Testing
- `npm run build` (from apps/web)
- ⚠️ `npm run build:web` (fails: turbo: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c5c16aa4148326b3c4bbb679387517